### PR TITLE
Fixed incorrect weight name

### DIFF
--- a/gptj.py
+++ b/gptj.py
@@ -81,7 +81,7 @@ def gptj_sequential(model, dataloader, dev):
         if args.true_sequential:
             sequential = [
                 ["attn.k_proj", "attn.v_proj", "attn.q_proj"],
-                ["attention.out_proj"],
+                ["attn.out_proj"],
                 ["mlp.fc_in"],
                 ["mlp.fc_out"],
             ]


### PR DESCRIPTION
It looks like the name for the output weight of the GPT-J model was incorrectly written as `attention.out_proj`. This should fix it, as the previous name was throwing out the following error:

```bash
Traceback (most recent call last):
  File "/home/anon/KoboldAI/repos/gptq/gptj.py", line 510, in <module>
    quantizers = gptj_sequential(model, dataloader, DEV)
  File "/home/anon/.pyenv/versions/3.10.11/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "/home/anon/KoboldAI/repos/gptq/gptj.py", line 92, in gptj_sequential
    subset = {n: full[n] for n in names}
  File "/home/anon/KoboldAI/repos/gptq/gptj.py", line 92, in <dictcomp>
    subset = {n: full[n] for n in names}
KeyError: 'attention.out_proj'
```
The correct layer names can be found in the `modeling_gptj.py` script [here](https://github.com/huggingface/transformers/blob/main/src/transformers/models/gptj/modeling_gptj.py#L259). 
