### PR TITLE
Create workflow build-wheels.yml

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -1,0 +1,46 @@
+name: Build Wheels
+
+on: workflow_dispatch
+
+jobs:
+  build_wheels:
+    name: Build wheel for ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    defaults:
+      run:
+        shell: pwsh
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+        with:
+          python-version: '3.8'
+        
+      - name: Setup Miniconda
+        uses: conda-incubator/setup-miniconda@v2.2.0
+        with:
+          auto-update-conda: true
+          activate-environment: "build"
+          python-version: 3.8
+          add-pip-as-python-dependency: true
+          auto-activate-base: false
+          
+      - name: Install Dependencies
+        run: |
+          conda install 'pytorch[version=2.0.0,build=py*_cuda11.8*]' 'pytorch-cuda=11.8' 'sentencepiece' 'cuda' 'ninja' -c 'pytorch' -c 'nvidia/label/cuda-11.8.0' -c 'nvidia' -c 'conda-forge' -c 'defaults'
+          python -m pip install build transformers==4.28.0 datasets safetensors accelerate==0.18.0
+
+      - name: Build Wheel
+        run: |
+          $env:CUDA_PATH = $env:CONDA_PREFIX
+          $env:CUDA_HOME = $env:CONDA_PREFIX
+          if ($IsLinux) {$env:LD_LIBRARY_PATH = $env:CONDA_PREFIX + '/lib:' + $env:LD_LIBRARY_PATH}
+          $env:TORCH_CUDA_ARCH_LIST = '3.5 3.7 5.0 5.2 6.0 6.1 7.0 7.5 8.0 8.6 8.9 9.0+PTX'
+          python -m build -n --wheel
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./dist/*.whl


### PR DESCRIPTION
Builds wheels for Windows and Linux. Currently configured for manual execution and uploads wheels as an artifact.

With some edits, can be configured to run automatically and upload wheels in a variety of ways.
For example, it can be set to build wheels when a release is created and upload them as assets for that release.