### PR TITLE
fix import transformers in opt.py

### DIFF
--- a/gptq/opt.py
+++ b/gptq/opt.py
@@ -257,6 +257,7 @@ def opt_pack(model, quantizers, wbits, groupsize):
 
 def load_quant(model, checkpoint, wbits, groupsize):
     from transformers import OPTConfig, OPTForCausalLM 
+    import transformers
     config = OPTConfig.from_pretrained(model)
     def noop(*args, **kwargs):
         pass


### PR DESCRIPTION
fix for `NameError: name 'transformers' is not defined` in load_quant():

This error was thrown when trying to load a model:

```
  File "aiserver.py", line 1980, in load_model
    model.load(
    │     └ <function InferenceModel.load at 0x00000191B2BC3430>
    └ <modeling.inference_models.hf_torch_4bit.HFTorch4BitInferenceModel object at 0x00000191BEDCF250>

  File "C:\1main\coding\repos\koboldAI\modeling\inference_model.py", line 177, in load
    self._load(save_model=save_model, initial_load=initial_load)
    │    │                │                        └ False
    │    │                └ True
    │    └ <function HFTorch4BitInferenceModel._load at 0x00000191B2BC5EE0>
    └ <modeling.inference_models.hf_torch_4bit.HFTorch4BitInferenceModel object at 0x00000191BEDCF250>

  File "C:\1main\coding\repos\koboldAI\modeling\inference_models\hf_torch_4bit.py", line 197, in _load
    self.model = self._get_model(self.get_local_model_path(), tf_kwargs)
    │    │       │    │          │    │                       └ {}
    │    │       │    │          │    └ <function HFInferenceModel.get_local_model_path at 0x00000191B2BC3E50>
    │    │       │    │          └ <modeling.inference_models.hf_torch_4bit.HFTorch4BitInferenceModel object at 0x00000191BEDCF250>
    │    │       │    └ <function HFTorch4BitInferenceModel._get_model at 0x00000191B2BC5F70>
    │    │       └ <modeling.inference_models.hf_torch_4bit.HFTorch4BitInferenceModel object at 0x00000191BEDCF250>
    │    └ None
    └ <modeling.inference_models.hf_torch_4bit.HFTorch4BitInferenceModel object at 0x00000191BEDCF250>

  File "C:\1main\coding\repos\koboldAI\modeling\inference_models\hf_torch_4bit.py", line 378, in _get_model
    model = load_quant_offload(opt_load_quant, utils.koboldai_vars.custmodpth, path_4bit, 4, groupsize, self.gpu_layers_list)
            │                  │               │     │                         │             │          │    └ [40]
            │                  │               │     │                         │             │          └ <modeling.inference_models.hf_torch_4bit.HFTorch4BitInferenceModel object at 0x00000191BEDCF250>
            │                  │               │     │                         │             └ 128
            │                  │               │     │                         └ 'C:\\1main\\coding\\repos\\koboldAI\\models\\OPT-13B-Erebus-4bit-128g\\4bit-128g.safetensors'
            │                  │               │     └ <koboldai_settings.koboldai_vars object at 0x00000191B6EEC6D0>
            │                  │               └ <module 'utils' from 'C:\\1main\\coding\\repos\\koboldAI\\utils.py'>
            │                  └ <function load_quant at 0x00000191B6F60F70>
            └ <function load_quant_offload at 0x00000191B708CF70>

  File "C:\1main\coding\libs\mamba\envs\koboldai\lib\site-packages\gptq\offload.py", line 971, in load_quant_offload
    model = load_quant_func(model, checkpoint, wbits, groupsize)
            │               │      │           │      └ 128
            │               │      │           └ 4
            │               │      └ 'C:\\1main\\coding\\repos\\koboldAI\\models\\OPT-13B-Erebus-4bit-128g\\4bit-128g.safetensors'
            │               └ 'C:\\1main\\coding\\repos\\koboldAI\\models\\OPT-13B-Erebus-4bit-128g'
            └ <function load_quant at 0x00000191B6F60F70>

  File "C:\1main\coding\libs\mamba\envs\koboldai\lib\site-packages\gptq\opt.py", line 268, in load_quant
    transformers.modeling_utils._init_weights = False

NameError: name 'transformers' is not defined
```

