### PR TITLE
WIP: Add MultiGPU support

### DIFF
--- a/gptq/llama.py
+++ b/gptq/llama.py
@@ -43,6 +43,10 @@ def llama_sequential(model, dataloader, dev):
     gpus = [torch.device('cuda:%d' % i) for i in range(torch.cuda.device_count())]
     if len(gpus) > 1:
         llama_multigpu(model, gpus)
+    else:
+        model.model.embed_tokens = model.model.embed_tokens.to(dev)
+        model.model.norm = model.model.norm.to(dev)
+        layers[0] = layers[0].to(dev)
 
     dtype = next(iter(model.parameters())).dtype
     inps = torch.zeros(

--- a/gptq/llama.py
+++ b/gptq/llama.py
@@ -287,7 +287,7 @@ def load_quant(model, checkpoint, wbits, groupsize=-1):
 
     return model
 
-def llama_multigpu(model, gpus):
+def llama_multigpu(model, gpus): #
     model.model.embed_tokens = model.model.embed_tokens.to(gpus[0])
     if hasattr(model.model, 'norm') and model.model.norm:
         model.model.norm = model.model.norm.to(gpus[-1])
@@ -316,7 +316,7 @@ def llama_multigpu(model, gpus):
     for i in range(len(layers)):
         layers[i] = MoveModule(layers[i].to(gpus[i // pergpu]))
 
-    model.gpus = gpus
+    model.gpus = gpus 
 
 def benchmark(model, input_ids, check=False):
     input_ids = input_ids.to(model.gpus[0] if hasattr(model, 'gpus') else DEV)

--- a/gptq/llama.py
+++ b/gptq/llama.py
@@ -464,7 +464,7 @@ if __name__ == '__main__':
         help='Whether to use the new PTB and C4 eval'
     )
     parser.add_argument(
-        '--maxgpuram', type=str, nargs=+, default='4GB',
+        '--maxgpuram', type=str, nargs='+', default='4GB',
         help='Set the max GPU RAM you want to use. Able to be set for GPU 1 and GPU 2'
     )
     parser.add_argument(

--- a/gptq/llama.py
+++ b/gptq/llama.py
@@ -295,8 +295,8 @@ def load_quant(model, checkpoint, wbits, groupsize=-1):
 
 def llama_multigpu(model, gpus):
     model.model.embed_tokens = model.model.embed_tokens.to(gpus[0])
-#    if hasattr(model.model, 'norm') and model.model.norm:
-#        model.model.norm = model.model.norm.to(gpus[-1])
+    if hasattr(model.model, 'norm') and model.model.norm:
+        model.model.norm = model.model.norm.to(gpus[-1])
     import copy
     model.lm_head = copy.deepcopy(model.lm_head).to(gpus[-1])
 

--- a/gptq/modelutils.py
+++ b/gptq/modelutils.py
@@ -10,12 +10,7 @@ from . import quant_v3
 GPTQVERSION = int(os.environ.get("GPTQVERSION", 1))
 if GPTQVERSION < 0 or GPTQVERSION > 2:
     raise NotImplementedError(f"Unsupported gptq version: {GPTQVERSION}")
-gpus = [torch.device('cuda:%d' % i) for i in range(torch.cuda.device_count())]
-DEV = ""
-if len(gpus) > 1:
-    GPUS = gpus
-else:
-    DEV = torch.device('cuda:0')
+DEV = torch.device('cuda:0')
 
 
 def find_layers(module, layers=[nn.Conv2d, nn.Linear], name=''):

--- a/gptq/modelutils.py
+++ b/gptq/modelutils.py
@@ -10,7 +10,12 @@ from . import quant_v3
 GPTQVERSION = int(os.environ.get("GPTQVERSION", 1))
 if GPTQVERSION < 0 or GPTQVERSION > 2:
     raise NotImplementedError(f"Unsupported gptq version: {GPTQVERSION}")
-DEV = torch.device('cuda:0')
+gpus = [torch.device('cuda:%d' % i) for i in range(torch.cuda.device_count())]
+DEV = ""
+if len(gpus) > 1:
+    GPUS = gpus
+else:
+    DEV = torch.device('cuda:0')
 
 
 def find_layers(module, layers=[nn.Conv2d, nn.Linear], name=''):


### PR DESCRIPTION
Goal is to allow multiple GPUs to pool together their VRAM for use during evaluation and quantization. Goal is also to be able to set a maximum amount of memory to use per GPU and have the rest of the data offloaded to CPU RAM.

Motivation: 16gb VRAM GPU runs out of memory evaluating a 30b model on C4-new dataset. It also runs OOM during quantization


I believe a mixture of the current multi-gpu code(for benchmarks) and the CPU offloading scripts will be useful for achieving this