### PR TITLE
Incorrect bit shift applied to 8bit models

### DIFF
--- a/gptq/quant_v2.py
+++ b/gptq/quant_v2.py
@@ -374,11 +374,11 @@ class QuantLinear(nn.Module):
                 
             elif self.bits == 8:
                 # Unpack 8bit weights
-                weight = torch.bitwise_right_shift(torch.unsqueeze(self.qweight, 1).expand(-1, 4, -1), self.wf1).to(torch.int8)
+                weight = torch.bitwise_right_shift(torch.unsqueeze(self.qweight, 1).expand(-1, 4, -1), self.wf1).to(torch.int16)
                 torch.bitwise_and(weight, 0x000000FF, out=weight)
                 weight = weight.reshape(-1, self.groupsize, weight.shape[2])
 
-                zeros = torch.bitwise_right_shift(torch.unsqueeze(self.qzeros, 2).expand(-1, -1, 4), self.wf2).to(torch.int8)
+                zeros = torch.bitwise_right_shift(torch.unsqueeze(self.qzeros, 2).expand(-1, -1, 4), self.wf2).to(torch.int16)
                 torch.bitwise_and(zeros, 0x000000FF, out=zeros)
                 zeros = zeros + 1
                 zeros = zeros.reshape(-1, 1, zeros.shape[1] * zeros.shape[2])


### PR DESCRIPTION
Fixing incorrect bit math that was causing complete incoherence when running inference on any configuration of 8bit GPTQ models, fix based off of qwopqwop's existing implementation:
 - https://github.com/qwopqwop200/GPTQ-for-LLaMa/commit/608f3ba71e40596c75f8864d73506eaf57323c6e
 
 Current 8bit behavior:
 
![image](https://github.com/0cc4m/GPTQ-for-LLaMa/assets/31778205/b503e4bf-bbce-4926-8d97-91a2bd86015d)

 Behavior after change:

![image](https://github.com/0cc4m/GPTQ-for-LLaMa/assets/31778205/5f5450a8-d57d-4724-8ae3-5f849485af83)
